### PR TITLE
fix: Import docker image in k3s ctr

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,8 +117,9 @@ jobs:
           export WORKER_TEST_IMG="dockerhubaneo/armonik-sdk-worker-test"
           ./tools/build-deploy-end2end.sh "${{ matrix.dist }}" "$WORKER_IMG" "${{ needs.versionning.outputs.version}}" "$ARMONIK_API_VERSION_DEFAULT" "$WORKER_TEST_IMG"
           ./tools/build-client.sh "$CLIENT_IMG" "${{ needs.versionning.outputs.version}}" "$API_VERSION"
-          echo "worker_img=$WORKER_IMG" >> $GITHUB_OUTPUT
           export WORKER_VERSION="${{ needs.versionning.outputs.version}}-$(echo "${{ matrix.dist }}" | awk '{print tolower($0)}')"
+          docker save "$WORKER_IMG:$WORKER_VERSION" | sudo k3s ctr images import /dev/stdin
+          echo "worker_img=$WORKER_IMG" >> $GITHUB_OUTPUT
           echo "worker_version=$WORKER_VERSION" >> $GITHUB_OUTPUT
           echo "client_img=$CLIENT_IMG" >> $GITHUB_OUTPUT
           echo "client_version=${{ needs.versionning.outputs.version}}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
After https://github.com/aneoconsulting/Armonik.Action.Deploy/pull/12, K3s does not user docker. An explicit image import is required to use the newly built image in K3s.