### PR TITLE
chore: use core version specified in ArmoniK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,7 +139,6 @@ jobs:
         with:
           working-directory: ${{ github.workspace }}/infra
           type: localhost
-          core-version: 0.28.0
 
       - name: Run Client tests
         timeout-minutes: 5


### PR DESCRIPTION
Use core version specified in armonik.

This will match the infra version for tests .
This will allow to test in pipeline with latest version in armoniK repository.