### PR TITLE
chore: handle exceptions thrown by the worker code

### DIFF
--- a/ArmoniK.SDK.Client.Test/include/End2EndHandlers.h
+++ b/ArmoniK.SDK.Client.Test/include/End2EndHandlers.h
@@ -95,3 +95,15 @@ public:
   long failure = 0;
   armonik::api::common::logger::LocalLogger logger;
 };
+
+class ExceptionServiceHandler final : public ArmoniK::Sdk::Client::IServiceInvocationHandler {
+public:
+  explicit ExceptionServiceHandler(armonik::api::common::logger::Logger &logger);
+  void HandleResponse(const std::string &result_payload, const std::string &taskId) override;
+  void HandleError(const std::exception &e, const std::string &taskId) override;
+
+  std::mutex mutex;
+  bool received = false;
+  bool is_error = false;
+  armonik::api::common::logger::LocalLogger logger;
+};

--- a/ArmoniK.SDK.Client.Test/src/ArmoniK.SDK.Client.Test.cpp
+++ b/ArmoniK.SDK.Client.Test/src/ArmoniK.SDK.Client.Test.cpp
@@ -622,3 +622,53 @@ TEST(testSDK, testLargePayload) {
   service.CloseSession();
   std::cout << "Large payload test done!" << std::endl;
 }
+
+class ExceptionServiceTest : public ::testing::TestWithParam<std::string> {};
+
+TEST_P(ExceptionServiceTest, HandlesExceptionCases) {
+  const std::string name = GetParam();
+
+  std::cout << "Testing Exception service..." << std::endl;
+
+  ArmoniK::Sdk::Common::Configuration config;
+  config.add_json_configuration("appsettings.json").add_env_configuration();
+
+  std::cout << "Endpoint : " << config.get("GrpcClient__Endpoint") << std::endl;
+  if (config.get("Worker__Type").empty()) {
+    config.set("Worker__Type", "End2EndTest");
+  }
+
+  ArmoniK::Sdk::Common::TaskOptions session_task_options("libArmoniK.SDK.Worker.Test.so",
+                                                         config.get("WorkerLib__Version"), "End2EndTest",
+                                                         "ExceptionService", config.get("PartitionId"));
+  session_task_options.max_retries = 1;
+
+  ArmoniK::Sdk::Common::Properties properties{config, session_task_options};
+
+  armonik::api::common::logger::Logger logger{armonik::api::common::logger::writer_console(),
+                                              armonik::api::common::logger::formatter_plain(true),
+                                              armonik::api::common::logger::Level::Debug};
+
+  ArmoniK::Sdk::Client::SessionService service(properties, logger);
+
+  std::cout << "Session : " << service.getSession() << std::endl;
+
+  auto handler = std::make_shared<ExceptionServiceHandler>(logger);
+  std::string args = "Exception success";
+
+  auto tasks = service.Submit({ArmoniK::Sdk::Common::TaskPayload(name, args)}, handler);
+
+  std::cout << "Sent : " << tasks[0] << std::endl;
+
+  service.WaitResults();
+
+  ASSERT_TRUE(!args.empty());
+  ASSERT_TRUE(handler->received);
+  ASSERT_TRUE(handler->is_error);
+
+  service.CloseSession();
+  std::cout << "Done" << std::endl;
+}
+
+INSTANTIATE_TEST_SUITE_P(ExceptionCases, ExceptionServiceTest,
+                         ::testing::Values(std::string("runTimeError"), std::string("logicalError")));

--- a/ArmoniK.SDK.Client.Test/src/ArmoniK.SDK.Client.Test.cpp
+++ b/ArmoniK.SDK.Client.Test/src/ArmoniK.SDK.Client.Test.cpp
@@ -670,5 +670,4 @@ TEST_P(ExceptionServiceTest, HandlesExceptionCases) {
   std::cout << "Done" << std::endl;
 }
 
-INSTANTIATE_TEST_SUITE_P(ExceptionCases, ExceptionServiceTest,
-                         ::testing::Values(std::string("runTimeError")));
+INSTANTIATE_TEST_SUITE_P(ExceptionCases, ExceptionServiceTest, ::testing::Values(std::string("runTimeError")));

--- a/ArmoniK.SDK.Client.Test/src/ArmoniK.SDK.Client.Test.cpp
+++ b/ArmoniK.SDK.Client.Test/src/ArmoniK.SDK.Client.Test.cpp
@@ -671,4 +671,4 @@ TEST_P(ExceptionServiceTest, HandlesExceptionCases) {
 }
 
 INSTANTIATE_TEST_SUITE_P(ExceptionCases, ExceptionServiceTest,
-                         ::testing::Values(std::string("runTimeError"), std::string("logicalError")));
+                         ::testing::Values(std::string("runTimeError")));

--- a/ArmoniK.SDK.Client.Test/src/End2EndHandlers.cpp
+++ b/ArmoniK.SDK.Client.Test/src/End2EndHandlers.cpp
@@ -170,3 +170,29 @@ void CountServiceHandler::HandleError(const std::exception &e, const std::string
   logger.log(armonik::api::common::logger::Level::Debug, ss.str(),
              {{"success", std::to_string(success)}, {"failure", std::to_string(failure)}});
 }
+void ExceptionServiceHandler::HandleResponse(const std::string &result_payload, const std::string &taskId) {
+  std::lock_guard<std::mutex> lock(mutex);
+
+  std::stringstream ss;
+  ss << "HANDLE RESPONSE : Received result of size " << result_payload.size() << " for taskId " << taskId
+     << "\nContent : ";
+  ss.write(result_payload.data(), result_payload.size()) << "\nRaw : ";
+  for (char c : result_payload) {
+    ss << static_cast<int>(c) << ' ';
+  }
+  ss << std::endl;
+  logger.debug(ss.str());
+  received = true;
+  is_error = false;
+}
+void ExceptionServiceHandler::HandleError(const std::exception &e, const std::string &taskId) {
+  std::lock_guard<std::mutex> lock(mutex);
+
+  std::stringstream ss;
+  ss << "HANDLE ERROR : Error for task id " << taskId << " : " << e.what() << std::endl;
+  logger.debug(ss.str());
+  received = true;
+  is_error = true;
+}
+ExceptionServiceHandler::ExceptionServiceHandler(armonik::api::common::logger::Logger &logger)
+    : logger(logger.local()) {}

--- a/ArmoniK.SDK.Client/src/SessionServiceImpl.cpp
+++ b/ArmoniK.SDK.Client/src/SessionServiceImpl.cpp
@@ -467,7 +467,7 @@ void SessionServiceImpl::WaitResults(std::set<std::string> task_ids, WaitBehavio
             if (handler) {
               handler->HandleResponse(payload, task_id);
             } else {
-              logger_.warning("No handler to deliver result " + result.result_id());
+              logger_.debug("No handler to deliver result " + result.result_id());
             }
           } catch (const std::exception &e) {
             handle_error(e, "Failed to execute result handler");

--- a/ArmoniK.SDK.DynamicWorker/src/DynamicWorker.cpp
+++ b/ArmoniK.SDK.DynamicWorker/src/DynamicWorker.cpp
@@ -1,5 +1,6 @@
 #include "DynamicWorker.h"
 #include "ApplicationManager.h"
+#include <exception>
 #include <armonik/sdk/common/ArmoniKSdkException.h>
 #include <armonik/sdk/common/TaskPayload.h>
 namespace ArmoniK {
@@ -27,6 +28,10 @@ DynamicWorker::Execute(armonik::api::worker::TaskHandler &taskHandler) {
         .Execute(taskHandler, taskPayload.method_name, taskPayload.arguments);
   } catch (const ArmoniK::Sdk::Common::ArmoniKSdkException &e) {
     return armonik::api::worker::ProcessStatus(e.what());
+  } catch (const std::exception &e) {
+    return armonik::api::worker::ProcessStatus(e.what());
+  } catch (...) {
+    return armonik::api::worker::ProcessStatus("Unknown exception");
   }
 
   return armonik::api::worker::ProcessStatus::Ok;

--- a/ArmoniK.SDK.DynamicWorker/src/DynamicWorker.cpp
+++ b/ArmoniK.SDK.DynamicWorker/src/DynamicWorker.cpp
@@ -1,8 +1,8 @@
 #include "DynamicWorker.h"
 #include "ApplicationManager.h"
-#include <exception>
 #include <armonik/sdk/common/ArmoniKSdkException.h>
 #include <armonik/sdk/common/TaskPayload.h>
+#include <exception>
 namespace ArmoniK {
 namespace Sdk {
 namespace DynamicWorker {

--- a/ArmoniK.SDK.DynamicWorker/src/DynamicWorker.cpp
+++ b/ArmoniK.SDK.DynamicWorker/src/DynamicWorker.cpp
@@ -23,9 +23,9 @@ DynamicWorker::Execute(armonik::api::worker::TaskHandler &taskHandler) {
     ServiceId serviceId(appId, taskHandler.getTaskOptions().application_namespace(),
                         taskHandler.getTaskOptions().application_service());
     return manager.UseApplication(appId)
-                  .UseService(serviceId)
-                  .UseSession(taskHandler.getSessionId())
-                  .Execute(taskHandler, taskPayload.method_name, taskPayload.arguments);
+        .UseService(serviceId)
+        .UseSession(taskHandler.getSessionId())
+        .Execute(taskHandler, taskPayload.method_name, taskPayload.arguments);
   } catch (const ArmoniK::Sdk::Common::ArmoniKSdkException &e) {
     return armonik::api::worker::ProcessStatus(e.what());
   }

--- a/ArmoniK.SDK.DynamicWorker/src/DynamicWorker.cpp
+++ b/ArmoniK.SDK.DynamicWorker/src/DynamicWorker.cpp
@@ -22,19 +22,13 @@ DynamicWorker::Execute(armonik::api::worker::TaskHandler &taskHandler) {
     AppId appId{taskHandler.getTaskOptions().application_name(), taskHandler.getTaskOptions().application_version()};
     ServiceId serviceId(appId, taskHandler.getTaskOptions().application_namespace(),
                         taskHandler.getTaskOptions().application_service());
-    manager.UseApplication(appId)
-        .UseService(serviceId)
-        .UseSession(taskHandler.getSessionId())
-        .Execute(taskHandler, taskPayload.method_name, taskPayload.arguments);
+    return manager.UseApplication(appId)
+                  .UseService(serviceId)
+                  .UseSession(taskHandler.getSessionId())
+                  .Execute(taskHandler, taskPayload.method_name, taskPayload.arguments);
   } catch (const ArmoniK::Sdk::Common::ArmoniKSdkException &e) {
     return armonik::api::worker::ProcessStatus(e.what());
-  } catch (const std::exception &e) {
-    return armonik::api::worker::ProcessStatus(e.what());
-  } catch (...) {
-    return armonik::api::worker::ProcessStatus("Unknown exception");
   }
-
-  return armonik::api::worker::ProcessStatus::Ok;
 }
 } // namespace DynamicWorker
 } // namespace Sdk

--- a/ArmoniK.SDK.DynamicWorker/src/ServiceManager.cpp
+++ b/ArmoniK.SDK.DynamicWorker/src/ServiceManager.cpp
@@ -42,9 +42,7 @@ armonik::api::worker::ProcessStatus ServiceManager::Execute(armonik::api::worker
   auto status = functionPointers.call(&callContext, service_context, session_context, method_name.c_str(),
                                       method_arguments.data(), method_arguments.size(), ServiceManager::UploadResult);
   if (status != ARMONIK_STATUS_OK) {
-    if (callContext.output.ok()) {
-      return armonik::api::worker::ProcessStatus("Unknown error in worker, check logs.");
-    }
+    throw ArmoniK::Sdk::Common::ArmoniKSdkException(callContext.output.details());
   }
   callContext.output.set_ok();
   return callContext.output;

--- a/ArmoniK.SDK.DynamicWorker/src/ServiceManager.cpp
+++ b/ArmoniK.SDK.DynamicWorker/src/ServiceManager.cpp
@@ -42,9 +42,12 @@ armonik::api::worker::ProcessStatus ServiceManager::Execute(armonik::api::worker
   auto status = functionPointers.call(&callContext, service_context, session_context, method_name.c_str(),
                                       method_arguments.data(), method_arguments.size(), ServiceManager::UploadResult);
   if (status != ARMONIK_STATUS_OK) {
-    throw ArmoniK::Sdk::Common::ArmoniKSdkException(callContext.output.details());
+    if (callContext.output.ok()) {
+      callContext.output.set_error("Unknown error in worker, check logs.");
+    }
+  } else {
+    callContext.output.set_ok();
   }
-  callContext.output.set_ok();
   return callContext.output;
 }
 

--- a/ArmoniK.SDK.Worker.Test/include/ExceptionService.h
+++ b/ArmoniK.SDK.Worker.Test/include/ExceptionService.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <armonik/sdk/worker/ServiceBase.h>
+#include <iostream>
+namespace ArmoniK {
+namespace Sdk {
+namespace Worker {
+namespace Test {
+
+/**
+ * @brief Example implementation of a ArmoniK::Sdk::Worker::ServiceBase
+ */
+class ExceptionService : ServiceBase {
+public:
+  std::string call(void *, const std::string &name, const std::string &input) override {
+    std::cout << "ExceptionService method : " << name << std::endl;
+    if (name == "runTimeError") {
+      throw std::runtime_error("Not implemented method");
+    }
+    throw std::logic_error("Logic error in method");
+  }
+
+  void *enter_session(const char *session_id) override {
+    std::cout << "ExceptionService entering session : " << session_id << std::endl;
+    return new std::string(session_id);
+  }
+  void leave_session(void *session_ctx) override {
+    auto session_id = static_cast<std::string *>(session_ctx);
+    std::cout << "ExceptionService leaving session : " << *session_id << std::endl;
+    delete session_id;
+  }
+  ~ExceptionService() override { std::cout << "Deleted ExceptionService" << std::endl; };
+
+  ExceptionService() : ServiceBase() { std::cout << "Created ExceptionService" << std::endl; }
+};
+
+} // namespace Test
+} // namespace Worker
+} // namespace Sdk
+} // namespace ArmoniK

--- a/ArmoniK.SDK.Worker.Test/src/ServiceDispatch.cpp
+++ b/ArmoniK.SDK.Worker.Test/src/ServiceDispatch.cpp
@@ -4,6 +4,7 @@
 
 #include "AdditionService.h"
 #include "EchoService.h"
+#include "ExceptionService.h"
 #include "SegFaultService.h"
 #include "SleepService.h"
 #include "StressTest.h"
@@ -20,8 +21,9 @@ extern "C" void *armonik_create_service(const char *service_namespace, const cha
     return new ArmoniK::Sdk::Worker::Test::SegFaultService();
   } else if (std::strcmp(service_name, "SleepService") == 0) {
     return new ArmoniK::Sdk::Worker::Test::SleepService();
+  } else if (std::strcmp(service_name, "ExceptionService") == 0) {
+    return new ArmoniK::Sdk::Worker::Test::ExceptionService();
   }
-
   std::cout << "Unknown service < " << service_namespace << "::" << service_name << " >" << std::endl;
   throw std::runtime_error(std::string("Unknown service <") + service_namespace + "::" + service_name + ">");
 }


### PR DESCRIPTION
# Motivation

`DynamicWorker::Execute`  calls a C function that its self calls C++ code internally.  If these C++ code throws, the C wrapper catches and stores the exception info in a `callContext` object and returns a non-zero status.  Such context was not being properly returned.

# Changes

Correct the  `ProcessStatus`  that should be returned by the `DynamicWorker::Execute` and fix the logic how `ServiceManager::Execute` consumes it.  Added unit test to validate the corrected behavior. 

# Other changes

Add `try/catch` block for the `handleError` call in Client's code
 
