### PR TITLE
ci: harmonize AK pipeline deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,11 +127,6 @@ jobs:
 
       - name: Login Docker
         run: echo ${{ secrets.DOCKER_HUB_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_LOGIN }} --password-stdin
-  
-      - name: Override parameters tfvars
-        run: |
-          cat ${{ github.workspace }}/infra/versions.tfvars.json | jq --arg worker "${{ steps.build.outputs.worker_img }}" --arg version "${{ steps.build.outputs.worker_version }}" '.armonik_versions.samples=$version | .armonik_images.samples+=[$worker]' > .versions.tfvars.json
-          mv .versions.tfvars.json ${{ github.workspace }}/infra/versions.tfvars.json
 
       - id: deploy
         name: Deploy
@@ -139,21 +134,23 @@ jobs:
         with:
           working-directory: ${{ github.workspace }}/infra
           type: localhost
+          override-compute: true
+          override-worker-version: ${{ steps.build.outputs.worker_version }}
+          override-worker-image:  ${{ steps.build.outputs.worker_img }}
+          override-worker-partition: cppdynamic
 
       - name: Run Client tests
         timeout-minutes: 5
         run: |
           set -ex
-          kubectl set image deployment/compute-plane-default -n armonik worker-0=${{ steps.build.outputs.worker_img}}:${{ steps.build.outputs.worker_version }}
-          export CPIP=$(kubectl get svc control-plane -n armonik -o custom-columns="IP:.spec.clusterIP" --no-headers=true)
-          export CPPort=$(kubectl get svc control-plane -n armonik -o custom-columns="PORT:.spec.ports[*].port" --no-headers=true)
-          docker run --rm -t --network host -e GrpcClient__Endpoint=http://$CPIP:$CPPort -e WorkerLib__Version="${{ needs.versionning.outputs.version}}" "${{ steps.build.outputs.client_img}}:${{ needs.versionning.outputs.version}}"
+          export CONTROL_PLANE_URL=$(jq -r .armonik.control_plane_url "${{ steps.deploy.outputs.generated-folder }}/armonik-output.json")
+          docker run --rm -t --network host -e GrpcClient__Endpoint="${CONTROL_PLANE_URL}" -e PartitionId=cppdynamic -e WorkerLib__Version="${{ needs.versionning.outputs.version}}" "${{ steps.build.outputs.client_img}}:${{ needs.versionning.outputs.version}}"
 
       - name: Push Docker
         run: |
-          docker push "${{ steps.build.outputs.worker_img}}:${{ steps.build.outputs.worker_version }}"
-          docker push "${{ steps.build.outputs.worker_test_img}}":"build-${{ matrix.dist }}"
-          docker push "${{ steps.build.outputs.client_img}}:${{ steps.build.outputs.client_version }}"
+          docker push "${{ steps.build.outputs.worker_img }}:${{ steps.build.outputs.worker_version }}"
+          docker push "${{ steps.build.outputs.worker_test_img }}":"build-${{ matrix.dist }}"
+          docker push "${{ steps.build.outputs.client_img }}:${{ steps.build.outputs.client_version }}"
           
   build-upload-artifact:
     strategy:


### PR DESCRIPTION
# Motivation

  The CI pipeline for deploying ArmoniK was using a manual `jq` command to patch the `versions.tfvars.json` file and `kubectl set image` to update the worker image after deployment. These steps are brittle and diverge from how other ArmoniK repositories drive their CI deployments.

  # Description

  Align the deployment step in `.github/workflows/build.yml` with the standard ArmoniK pipeline action interface:

  - Remove the manual `Override parameters tfvars` step that patched `versions.tfvars.json` via `jq`.
  - Pass the worker image and version directly to the deploy action via the new `override-compute`, `override-worker-version`, `override-worker-image`, and `override-worker-partition` inputs.
  - Remove the post-deploy `kubectl set image` command; the control-plane URL is now read from the action's `generated-folder` output (`armonik-output.json`) and passed directly to the test
  container.
  - Add `PartitionId=cppdynamic` to the client test invocation so it targets the correct partition.
  - Minor whitespace fix: add a space before `:` in all three `docker push` commands.

  # Testing

  The workflow is exercised on every push/PR by the existing CI pipeline. The deploy action used here is the same action already validated across other ArmoniK repositories.                   
   
  # Impact                                                                                                                                                                                      
                  
  - No functional change to the built artifacts or test logic.
  - Deployment configuration is now driven by the action's own override mechanism, reducing the risk of version drift between the tfvars file and the actual image being tested.
  - Removes a dependency on `kubectl` being available post-deploy to patch the running deployment.
                                                                                                                                                                                                
  # Additional Information
                                                                                                                                                                                                
  This change assumes the deploy action (`type: localhost`) supports the `override-compute`, `override-worker-version`, `override-worker-image`, and `override-worker-partition` inputs. Verify 
  the action version in use exposes these inputs before merging.
                                                                                                                                                                                                
  # Checklist     

  - [x] My code adheres to the coding and style guidelines of the project.
  - [x] I have performed a self-review of my code.
  - [x] I have commented my code, particularly in hard-to-understand areas.                                                                                                                     
  - [x] I have made corresponding changes to the documentation.
  - [x] I have thoroughly tested my modifications and added tests when necessary.                                                                                                               
  - [x] Tests pass locally and in the CI.
  - [x] I have assessed the performance impact of my modifications.           