### PR TITLE
chore: sdk version into context logs

### DIFF
--- a/ArmoniK.SDK.Client/src/ChannelPool.cpp
+++ b/ArmoniK.SDK.Client/src/ChannelPool.cpp
@@ -1,6 +1,7 @@
 #include "ChannelPool.h"
 
 #include <armonik/client/channel/ChannelFactory.h>
+#include <armonik/sdk/common/Version.h>
 #include <armonik/common/options/ControlPlane.h>
 #include <armonik/common/utils/ChannelArguments.h>
 #include <grpcpp/create_channel.h>
@@ -75,7 +76,7 @@ bool ChannelPool::ShutdownOnFailure(std::shared_ptr<grpc::Channel> channel) {
 }
 
 ChannelPool::ChannelPool(ArmoniK::Sdk::Common::Properties properties, armonik::api::common::logger::Logger &logger)
-    : properties_(std::move(properties)), logger_(logger.local()) {}
+    : properties_(std::move(properties)), logger_(logger.local({{"sdk_version", ArmoniK::Sdk::Common::getVersion()}})) {}
 ChannelPool::~ChannelPool() = default;
 
 ChannelPool::ChannelGuard::ChannelGuard(Internal::ChannelPool *pool) : pool_(pool) {

--- a/ArmoniK.SDK.Client/src/ChannelPool.cpp
+++ b/ArmoniK.SDK.Client/src/ChannelPool.cpp
@@ -1,9 +1,9 @@
 #include "ChannelPool.h"
 
 #include <armonik/client/channel/ChannelFactory.h>
-#include <armonik/sdk/common/Version.h>
 #include <armonik/common/options/ControlPlane.h>
 #include <armonik/common/utils/ChannelArguments.h>
+#include <armonik/sdk/common/Version.h>
 #include <grpcpp/create_channel.h>
 #include <utility>
 
@@ -76,7 +76,8 @@ bool ChannelPool::ShutdownOnFailure(std::shared_ptr<grpc::Channel> channel) {
 }
 
 ChannelPool::ChannelPool(ArmoniK::Sdk::Common::Properties properties, armonik::api::common::logger::Logger &logger)
-    : properties_(std::move(properties)), logger_(logger.local({{"sdk_version", ArmoniK::Sdk::Common::getVersion()}})) {}
+    : properties_(std::move(properties)), logger_(logger.local({{"sdk_version", ArmoniK::Sdk::Common::getVersion()}})) {
+}
 ChannelPool::~ChannelPool() = default;
 
 ChannelPool::ChannelGuard::ChannelGuard(Internal::ChannelPool *pool) : pool_(pool) {

--- a/ArmoniK.SDK.Client/src/SessionService.cpp
+++ b/ArmoniK.SDK.Client/src/SessionService.cpp
@@ -1,5 +1,6 @@
 #include "armonik/sdk/client/SessionService.h"
 #include "SessionServiceImpl.h"
+#include <armonik/sdk/common/Version.h>
 #include <string>
 #include <utility>
 
@@ -9,7 +10,8 @@ namespace Client {
 
 SessionService::SessionService(const ArmoniK::Sdk::Common::Properties &properties,
                                armonik::api::common::logger::Logger &logger, const std::string &session_id)
-    : impl(new Internal::SessionServiceImpl(properties, logger, session_id)), logger_(logger.local()) {}
+    : impl(new Internal::SessionServiceImpl(properties, logger, session_id)),
+      logger_(logger.local({{"sdk_version", ArmoniK::Sdk::Common::getVersion()}})) {}
 
 const std::string &SessionService::getSession() const {
   ensure_valid();

--- a/ArmoniK.SDK.Client/src/SessionServiceImpl.cpp
+++ b/ArmoniK.SDK.Client/src/SessionServiceImpl.cpp
@@ -14,6 +14,7 @@
 #include <armonik/common/utils/GuuId.h>
 #include <armonik/sdk/common/Properties.h>
 #include <armonik/sdk/common/TaskPayload.h>
+#include <armonik/sdk/common/Version.h>
 #include <chrono>
 #include <thread>
 #include <utility>
@@ -293,7 +294,8 @@ SessionServiceImpl::Submit(const std::vector<Common::TaskPayload> &task_requests
 SessionServiceImpl::SessionServiceImpl(const Common::Properties &properties,
                                        armonik::api::common::logger::Logger &logger, const std::string &session_id)
     : taskOptions(properties.taskOptions), channel_pool(properties, logger),
-      thread_pool_(properties.configuration.get_control_plane().getThreadPoolSize(), logger), logger_(logger.local()),
+      thread_pool_(properties.configuration.get_control_plane().getThreadPoolSize(), logger),
+      logger_(logger.local({{"sdk_version", ArmoniK::Sdk::Common::getVersion()}})),
       wait_batch_size_(properties.configuration.get_control_plane().getWaitBatchSize()),
       submit_batch_size_(properties.configuration.get_control_plane().getSubmitBatchSize()),
       override_message_size_(properties.configuration.get_control_plane().getOverrideMessageSize()) {

--- a/ArmoniK.SDK.Common/CMakeLists.txt
+++ b/ArmoniK.SDK.Common/CMakeLists.txt
@@ -12,6 +12,12 @@ FILE(GLOB_RECURSE HEADER_CLIENT_FILES ${HEADER_FILES_DIR}/*.h)
 
 find_package(ArmoniK.Api.Common CONFIG REQUIRED)
 
+configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/Version.h.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/include/armonik/sdk/common/Version.h"
+        @ONLY
+)
+
 add_library(${PROJECT_NAME} STATIC ${SRC_CLIENT_FILES} ${HEADER_CLIENT_FILES})
 
 target_link_libraries(${PROJECT_NAME} PUBLIC ArmoniK.Api.Common)
@@ -19,6 +25,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC ArmoniK.Api.Common)
 target_include_directories(${PROJECT_NAME}
         PUBLIC
         "$<BUILD_INTERFACE:${HEADER_FILES_DIR}>"
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
         "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
         )
 
@@ -41,6 +48,8 @@ install(TARGETS ${PROJECT_NAME}
         RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(DIRECTORY ${HEADER_FILES_DIR}/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} FILES_MATCHING PATTERN "*.h")
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/include/armonik/sdk/common/Version.h"
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/armonik/sdk/common)
 
 install(EXPORT ${PROJECT_NAME}Targets
         FILE ${PROJECT_NAME}Targets.cmake

--- a/ArmoniK.SDK.Common/Version.h.in
+++ b/ArmoniK.SDK.Common/Version.h.in
@@ -1,0 +1,10 @@
+#pragma once
+#include <string>
+
+namespace ArmoniK {
+namespace Sdk {
+namespace Common {
+inline std::string getVersion() { return "@VERSION@"; }
+} // namespace Common
+} // namespace Sdk
+} // namespace ArmoniK

--- a/ArmoniK.SDK.DynamicWorker/src/main.cpp
+++ b/ArmoniK.SDK.DynamicWorker/src/main.cpp
@@ -1,6 +1,7 @@
 #include "DynamicWorker.h"
 #include <armonik/sdk/common/Configuration.h>
 #include <armonik/sdk/common/TaskPayload.h>
+#include <armonik/sdk/common/Version.h>
 #include <armonik/worker/utils/WorkerServer.h>
 
 int main() {
@@ -9,6 +10,7 @@ int main() {
 
   armonik::api::common::logger::Logger logger{armonik::api::common::logger::writer_console(),
                                               armonik::api::common::logger::formatter_clef(), config.get_log_level()};
+  logger.global_context_add("sdk_version", ArmoniK::Sdk::Common::getVersion());
 
   logger.info("Starting ArmoniK SDK worker");
 


### PR DESCRIPTION
# Motivation

The SDK had no way to identify which compiled version was running, making it hard to correlate logs with a specific release.

# Description

Adds a `getVersion()` function to the `ArmoniK::Sdk::Common` namespace that returns the SDK version baked in at compile time, and ensures that version is included as a structured field in all log output.

**`ArmoniK.SDK.Common/Version.h.in`**
A CMake template that gets the `@VERSION@` placeholder substituted at configure time, generating an `armonik/sdk/common/Version.h` header with an `inline std::string getVersion()` function.

**`ArmoniK.SDK.Common/CMakeLists.txt`**

- Calls `configure_file` to produce `Version.h` in the build directory from `Version.h.in`.
- Adds the generated include directory as a `BUILD_INTERFACE` include path.
- Adds an `install(FILES ...)` rule so the generated header is installed alongside the static headers.

**`ArmoniK.SDK.DynamicWorker/src/main.cpp`**

Calls `logger.global_context_add("sdk_version", getVersion())` immediately after constructing the root logger. This propagates the version to every log line in the process, including all `LocalLogger` children.

**`ArmoniK.SDK.Client/src/SessionService.cpp`, `SessionServiceImpl.cpp`, `ChannelPool.cpp`**

Passes `{{"sdk_version", getVersion()}}` as the local context when constructing each internal `LocalLogger`. Since the client logger is user-owned, this injects the version into all SDK-internal log lines without modifying the caller's root logger.

# Testing

- Verified that `configure_file` correctly substitutes the version by inspecting the generated `Version.h` in the build directory.
- Verified the version field appears in structured log output (CLEF format) when executing tasks using the DynamicWorker.

# Impact

- No behaviour change. Log lines gain one additional structured field `sdk_version`.
- `Version.h` is generated at configure time; builds that do not pass `-DVERSION=` will see `"0.1.0-local"` (existing default).
- `ThreadPool` uses a `Logger&` reference rather than a `LocalLogger`, so its log lines will carry `sdk_version` only if the user calls `logger.global_context_add("sdk_version", getVersion())` on their root logger before constructing `SessionService`. 

# Additional Information

The version string follows the existing convention: it is set by the CI pipeline via `-DVERSION=<git-derived-version>` (computed by `codacy/git-version` on feature branches, or taken directly from the git tag on releases).
