### PR TITLE
fix(packaging): add nlohmann-json3-dev dependency to debian control

### DIFF
--- a/tools/packaging/debian/control
+++ b/tools/packaging/debian/control
@@ -14,6 +14,6 @@ Section: libs
 Architecture: any
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
-Depends: libgrpc-dev (>= 1.50), libgrpc++-dev (>= 1.50), libprotobuf-dev (>= 3.20), libc-ares-dev, protobuf-compiler-grpc (>= 1.50)
+Depends: libgrpc-dev (>= 1.50), libgrpc++-dev (>= 1.50), libprotobuf-dev (>= 3.20), libc-ares-dev, protobuf-compiler-grpc (>= 1.50), nlohmann-json3-dev
 Description: ArmoniK SDK libraries
     This includes the Common, Client and Worker SDKs


### PR DESCRIPTION
## Motivation

The `nlohmann/json` library is used by the ArmoniK SDK but was missing from the Debian package dependencies, causing installation failures on systems that don't have it pre-installed.

## Description

Adds `nlohmann-json3-dev` to the `Depends` field in `tools/packaging/debian/control` so that the Debian package correctly declares its runtime/build dependency on the nlohmann JSON library.

## Testing

No automated tests apply to packaging metadata changes. The fix can be validated by building and installing the `.deb` package on a clean Debian/Ubuntu system.

## Impact

- Debian package will now correctly pull in `nlohmann-json3-dev` as a dependency.
- No behaviour change to the SDK itself.

## Additional Information

A similar fix was previously applied for RHEL/UBI8 images (see commit 96acca9). This aligns the Debian packaging to the same standard.