### PR TITLE
fix(packaging): use /app/install prefix for nlohmann-json in ubi8

### DIFF
--- a/ArmoniK.SDK.DynamicWorker/ubi8.Dockerfile
+++ b/ArmoniK.SDK.DynamicWorker/ubi8.Dockerfile
@@ -24,7 +24,7 @@ RUN yum --disableplugin=subscription-manager clean all
 
 RUN git clone --depth 1 https://github.com/nlohmann/json.git -b v3.11.3 /tmp/nlohmann-json && \
     cmake -S /tmp/nlohmann-json -B /tmp/nlohmann-json/build \
-        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DCMAKE_INSTALL_PREFIX=/app/install \
         -DJSON_BuildTests=OFF && \
     cmake --build /tmp/nlohmann-json/build --target install && \
     rm -rf /tmp/nlohmann-json


### PR DESCRIPTION
## Motivation

In the ubi8 multi-stage Dockerfile, the runner stage only copies artifacts from `/app/install` (built in the builder stage). nlohmann-json was previously installed to `/usr/local`, which meant its headers and libraries were silently dropped when transitioning from the builder to the runner image. This would cause linking or runtime failures for any consumer relying on that library.

## Description

Change the `CMAKE_INSTALL_PREFIX` for the nlohmann-json build step from `/usr/local` to `/app/install`, consistent with the rest of the build (the worker itself is also installed to `/app/install`).

Affected file: `ArmoniK.SDK.DynamicWorker/ubi8.Dockerfile`

## Testing

The fix aligns the install prefix with the `COPY --from=builder /app/install/. /app/install/.` instruction already present in the Dockerfile. No new tests added; the change is a straightforward path correction.

## Impact

- nlohmann-json headers and libraries are now correctly included in the final runner image.
- No configuration or API changes.

## Additional Information

The equivalent issue does not exist in the debian Dockerfile, which installs nlohmann-json via `apt` (`nlohmann-json3-dev`) rather than building from source.

## Checklist

- [ ] The code builds and tests pass
- [ ] Documentation updated if needed