### PR TITLE
fix(packaging): add nlohmann_json find_dependency to client cmake config

### DIFF
--- a/ArmoniK.SDK.Client/Config.cmake.in
+++ b/ArmoniK.SDK.Client/Config.cmake.in
@@ -4,6 +4,7 @@ set_and_check(ARMONIK_SDK_CLIENT_PREFIX "@PACKAGE_CMAKE_INSTALL_PREFIX@")
 set_and_check(ARMONIK_SDK_CLIENT_LIBPATH "@PACKAGE_CMAKE_INSTALL_LIBDIR@")
 
 include(CMakeFindDependencyMacro)
+find_dependency(nlohmann_json)
 find_dependency(ArmoniK.SDK.Common CONFIG REQUIRED)
 find_dependency(ArmoniK.Api.Client CONFIG REQUIRED)
 


### PR DESCRIPTION
## Motivation

When consuming the `ArmoniK.SDK.Client` package via CMake, downstream projects could fail to resolve the `nlohmann_json` dependency at configuration time because it was not declared in the package's CMake config file. This was a gap left after `nlohmann_json` was added as a runtime dependency in the Debian/RHEL packaging.

## Description

Adds `find_dependency(nlohmann_json)` to `ArmoniK.SDK.Client/Config.cmake.in` so that CMake automatically finds and links `nlohmann_json` when a consumer calls `find_package(ArmoniK.SDK.Client)`.

Related to #80 (which added `nlohmann-json3-dev` to the Debian control file).

## Testing

No automated tests added — this is a CMake packaging fix. It can be verified by consuming the installed package from a downstream CMake project and confirming configuration succeeds without manually specifying `nlohmann_json`.

## Impact

- Downstream CMake consumers of `ArmoniK.SDK.Client` no longer need to manually call `find_package(nlohmann_json)` before finding this package.
- No behaviour change at runtime.

## Additional Information

This mirrors the pattern already used for `ArmoniK.SDK.Common` and `ArmoniK.Api.Client` in the same config file.