### PR TITLE
fix: add repository name to docker image tag in packaging scripts

### DIFF
--- a/tools/packaging/make-deb.sh
+++ b/tools/packaging/make-deb.sh
@@ -7,15 +7,16 @@ script_path="$(dirname "${BASH_SOURCE:-$0}")"
 working_dir="$(realpath "$script_path/../../" )"
 source "${script_path}"/../common.sh
 
-IMAGE_TAG="${1:-"armoniksdkdeb:${ARMONIK_SDK_VERSION_DEFAULT}"}"
+VERSION="${1:-"${ARMONIK_SDK_VERSION_DEFAULT}"}"
 API_VERSION="${2:-"${ARMONIK_API_VERSION_DEFAULT}"}"
+DOCKER_TAG="armoniksdkdeb:${VERSION}"
 
-docker build -t "${IMAGE_TAG}" \
+docker build -t "${DOCKER_TAG}" \
     -f deb.Dockerfile \
     --build-arg="API_VERSION=${API_VERSION}" \
-    --build-arg="WORKER_VERSION=${IMAGE_TAG}"  "${working_dir}"
+    --build-arg="WORKER_VERSION=${VERSION}"  "${working_dir}"
 
 mkdir -p ${working_dir}/build
 
 # Compile the project source using the Docker image
-docker run --rm -v ".:/host" --entrypoint bash "${IMAGE_TAG}" -c "cp ./*.deb /host/"
+docker run --rm -v ".:/host" --entrypoint bash "${DOCKER_TAG}" -c "cp ./*.deb /host/"

--- a/tools/packaging/make-rpm.sh
+++ b/tools/packaging/make-rpm.sh
@@ -7,16 +7,17 @@ script_path="$(dirname "${BASH_SOURCE:-$0}")"
 working_dir="$(realpath "$script_path/../../" )"
 source "${script_path}"/../common.sh
 
-IMAGE_TAG="${1:-"armoniksdkrpm:${ARMONIK_SDK_VERSION_DEFAULT}"}"
+VERSION="${1:-"${ARMONIK_SDK_VERSION_DEFAULT}"}"
 API_VERSION="${2:-"${ARMONIK_API_VERSION_DEFAULT}"}"
+DOCKER_TAG="armoniksdkrpm:${VERSION}"
 
-docker build -t "${IMAGE_TAG}" \
+docker build -t "${DOCKER_TAG}" \
     -f ubi8.Dockerfile \
     --build-arg="CPACK_GENERATOR=RPM" \
     --build-arg="API_VERSION=${API_VERSION}" \
-    --build-arg="WORKER_VERSION=${IMAGE_TAG}" "${working_dir}"
+    --build-arg="WORKER_VERSION=${VERSION}" "${working_dir}"
 
 mkdir -p ${working_dir}/build
 
 # Compile the project source using the Docker image
-docker run --rm -v ".:/host" --entrypoint bash "${IMAGE_TAG}" -c "cp ./*.rpm /host/"
+docker run --rm -v ".:/host" --entrypoint bash "${DOCKER_TAG}" -c "cp ./*.rpm /host/"


### PR DESCRIPTION
  `make-deb.sh` and `make-rpm.sh` utility scripts accept a version string as their first argument, but they were using that argument directly as the full Docker image reference. 
