### PR TITLE
fix: add repository name to docker image tag in tgz script

### DIFF
--- a/tools/packaging/make-tar.gz.sh
+++ b/tools/packaging/make-tar.gz.sh
@@ -7,16 +7,17 @@ script_path="$(dirname "${BASH_SOURCE:-$0}")"
 working_dir="$(realpath "$script_path/../../" )"
 source "${script_path}"/../common.sh
 
-IMAGE_TAG="${1:-"armoniksdktgz:${ARMONIK_SDK_VERSION_DEFAULT}"}"
+VERSION="${1:-"${ARMONIK_SDK_VERSION_DEFAULT}"}"
 API_VERSION="${2:-"${ARMONIK_API_VERSION_DEFAULT}"}"
+DOCKER_TAG="armoniksdktgz:${VERSION}"
 
-docker build -t "${IMAGE_TAG}" \
+docker build -t "${DOCKER_TAG}" \
     -f ubi8.Dockerfile \
     --build-arg="CPACK_GENERATOR=TGZ" \
     --build-arg="API_VERSION=${API_VERSION}" \
-    --build-arg="WORKER_VERSION=${IMAGE_TAG}" "${working_dir}"
+    --build-arg="WORKER_VERSION=${VERSION}" "${working_dir}"
 
 mkdir -p ${working_dir}/build
 
 # Compile the project source using the Docker image
-docker run --rm -v ".:/host" --entrypoint bash "${IMAGE_TAG}" -c "cp ./*.tar.gz /host/"
+docker run --rm -v ".:/host" --entrypoint bash "${DOCKER_TAG}" -c "cp ./*.tar.gz /host/"


### PR DESCRIPTION
follow up of #84 for the tar.gz packaging script