### PR TITLE
chore(string_view): switch from absl::string_view to internal API implementation

### DIFF
--- a/ArmoniK.SDK.Client.Test/src/End2EndHandlers.cpp
+++ b/ArmoniK.SDK.Client.Test/src/End2EndHandlers.cpp
@@ -1,3 +1,5 @@
+#include <algorithm>
+#include <cstring>
 #include <iostream>
 
 #include "End2EndHandlers.h"

--- a/ArmoniK.SDK.Client/src/SessionServiceImpl.cpp
+++ b/ArmoniK.SDK.Client/src/SessionServiceImpl.cpp
@@ -12,6 +12,7 @@
 #include <armonik/common/exceptions/ArmoniKTaskError.h>
 #include <armonik/common/objects.pb.h>
 #include <armonik/common/utils/GuuId.h>
+#include <armonik/common/utils/string_view.h>
 #include <armonik/sdk/common/DynamicLibrary.h>
 #include <armonik/sdk/common/Properties.h>
 #include <armonik/sdk/common/TaskDefinition.h>
@@ -39,7 +40,7 @@ namespace {
  * @param logger Logger
  */
 void upload_large_result(ArmoniK::Sdk::Client::Internal::ChannelPool &pool, std::string session, std::string result_id,
-                         absl::string_view data, std::size_t data_chunk_max_size,
+                         armonik::api::string_view data, std::size_t data_chunk_max_size,
                          armonik::api::common::logger::ILogger &logger) {
 
   std::exception_ptr eptr;

--- a/ArmoniK.SDK.Common/include/armonik/sdk/common/Configuration.h
+++ b/ArmoniK.SDK.Common/include/armonik/sdk/common/Configuration.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <absl/strings/string_view.h>
 #include <armonik/common/logger/fwd.h>
+#include <armonik/common/utils/string_view.h>
 #include <map>
 #include <memory>
 #include <string>
@@ -76,35 +76,35 @@ public:
    * @return Endpoint address
    * @note Configuration key: `GrpcClient__Endpoint`
    */
-  [[nodiscard]] absl::string_view getEndpoint() const;
+  [[nodiscard]] armonik::api::string_view getEndpoint() const;
 
   /**
    * @brief Path to the client's certificate in PEM format
    * @return Client certificate's path
    * @note Configuration key: `GrpcClient__CertPem` (optional)
    */
-  [[nodiscard]] absl::string_view getUserCertPemPath() const;
+  [[nodiscard]] armonik::api::string_view getUserCertPemPath() const;
 
   /**
    * @brief Path to the client's key in PEM format (PKCS#1 or PKCS#8)
    * @return Client key path
    * @note Configuration key: `GrpcClient__KeyPem` (optional)
    */
-  [[nodiscard]] absl::string_view getUserKeyPemPath() const;
+  [[nodiscard]] armonik::api::string_view getUserKeyPemPath() const;
 
   /**
    * @brief Path to the client's PKCS#12 certificate/key
    * @return Client P12 path
    * @note Configuration key: `GrpcClient__CertP12` (optional)
    */
-  [[nodiscard]] absl::string_view getUserP12Path() const;
+  [[nodiscard]] armonik::api::string_view getUserP12Path() const;
 
   /**
    * @brief Path to the server's CA certificate
    * @return CA certificate path
    * @note Configuration key: `GrpcClient__CaCert` (optional)
    */
-  [[nodiscard]] absl::string_view getCaCertPemPath() const;
+  [[nodiscard]] armonik::api::string_view getCaCertPemPath() const;
 
   /**
    * @brief Is SSL validation enabled ?
@@ -199,7 +199,7 @@ public:
    * @brief Returns the server address.
    * @return A reference to the server address string.
    */
-  [[nodiscard]] absl::string_view get_server_address() const;
+  [[nodiscard]] armonik::api::string_view get_server_address() const;
 
   /**
    * @brief Sets the worker address with the given socket address.
@@ -217,7 +217,7 @@ public:
    * @brief Returns the agent address.
    * @return A reference to the agent address string.
    */
-  [[nodiscard]] absl::string_view get_agent_address() const;
+  [[nodiscard]] armonik::api::string_view get_agent_address() const;
 
 private:
   std::unique_ptr<armonik::api::common::options::ComputePlane> impl;
@@ -288,7 +288,7 @@ public:
    * @param file_path Path to the JSON file.
    * @return Reference to the current Configuration object.
    */
-  Configuration &add_json_configuration(absl::string_view file_path);
+  Configuration &add_json_configuration(armonik::api::string_view file_path);
 
   /**
    * @brief Add environment variable configuration.

--- a/ArmoniK.SDK.Common/include/armonik/sdk/common/TaskPayload.h
+++ b/ArmoniK.SDK.Common/include/armonik/sdk/common/TaskPayload.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <absl/strings/string_view.h>
+#include <armonik/common/utils/string_view.h>
 #include <map>
 #include <sstream>
 #include <vector>
@@ -52,7 +52,7 @@ struct [[deprecated("Use TaskDefinition with Submit(std::vector<TaskDefinition>)
    * @param serialized Serialized payload
    * @return Deserialized payload
    */
-  static TaskPayload Deserialize(absl::string_view serialized);
+  static TaskPayload Deserialize(armonik::api::string_view serialized);
 };
 
 } // namespace Common

--- a/ArmoniK.SDK.Common/include/armonik/sdk/common/internal/ConventionPayload.h
+++ b/ArmoniK.SDK.Common/include/armonik/sdk/common/internal/ConventionPayload.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <absl/strings/string_view.h>
+#include <armonik/common/utils/string_view.h>
 #include <map>
 #include <string>
 
@@ -25,7 +25,7 @@ struct ConventionPayload {
   std::map<std::string, std::string> outputs;
 
   [[nodiscard]] std::string Serialize() const;
-  static ConventionPayload Deserialize(absl::string_view serialized);
+  static ConventionPayload Deserialize(armonik::api::string_view serialized);
 };
 
 } // namespace Common

--- a/ArmoniK.SDK.Common/src/Configuration.cpp
+++ b/ArmoniK.SDK.Common/src/Configuration.cpp
@@ -29,13 +29,13 @@ ComputePlane &ComputePlane::operator=(const ComputePlane &computeplane) {
 ComputePlane &ComputePlane::operator=(ComputePlane &&) noexcept = default;
 ComputePlane::~ComputePlane() = default;
 
-absl::string_view ComputePlane::get_server_address() const { return impl->get_server_address(); }
+armonik::api::string_view ComputePlane::get_server_address() const { return impl->get_server_address(); }
 void ComputePlane::set_worker_address(std::string socket_address) {
   impl->set_worker_address(std::move(socket_address));
 }
 
 void ComputePlane::set_agent_address(std::string agent_address) { impl->set_agent_address(std::move(agent_address)); }
-absl::string_view ComputePlane::get_agent_address() const { return impl->get_agent_address(); }
+armonik::api::string_view ComputePlane::get_agent_address() const { return impl->get_agent_address(); }
 
 const armonik::api::common::options::ComputePlane &ComputePlane::get_impl() const {
   const static armonik::api::common::options::ComputePlane default_config =
@@ -91,11 +91,11 @@ ControlPlane &ControlPlane::operator=(const ControlPlane &controlplane) {
 ControlPlane &ControlPlane::operator=(ControlPlane &&) noexcept = default;
 ControlPlane::~ControlPlane() = default;
 
-absl::string_view ControlPlane::getEndpoint() const { return impl->getEndpoint(); }
-absl::string_view ControlPlane::getUserCertPemPath() const { return impl->getUserCertPemPath(); }
-absl::string_view ControlPlane::getUserKeyPemPath() const { return impl->getUserKeyPemPath(); }
-absl::string_view ControlPlane::getUserP12Path() const { return impl->getUserP12Path(); }
-absl::string_view ControlPlane::getCaCertPemPath() const { return impl->getCaCertPemPath(); }
+armonik::api::string_view ControlPlane::getEndpoint() const { return impl->getEndpoint(); }
+armonik::api::string_view ControlPlane::getUserCertPemPath() const { return impl->getUserCertPemPath(); }
+armonik::api::string_view ControlPlane::getUserKeyPemPath() const { return impl->getUserKeyPemPath(); }
+armonik::api::string_view ControlPlane::getUserP12Path() const { return impl->getUserP12Path(); }
+armonik::api::string_view ControlPlane::getCaCertPemPath() const { return impl->getCaCertPemPath(); }
 bool ControlPlane::isSslValidation() const { return impl->isSslValidation(); }
 
 int ControlPlane::getWaitBatchSize() const { return wait_batch_size_; }
@@ -138,7 +138,7 @@ std::string Configuration::get(const std::string &key) const { return get_impl()
 void Configuration::set(const std::string &key, const std::string &value) { set_impl().set(key, value); }
 
 const std::map<std::string, std::string> &Configuration::list() const { return get_impl().list(); }
-Configuration &Configuration::add_json_configuration(absl::string_view file_path) {
+Configuration &Configuration::add_json_configuration(armonik::api::string_view file_path) {
   set_impl().add_json_configuration(file_path);
   return *this;
 }

--- a/ArmoniK.SDK.Common/src/TaskPayload.cpp
+++ b/ArmoniK.SDK.Common/src/TaskPayload.cpp
@@ -33,7 +33,7 @@ template <typename T> std::string int_to_hex(T i) {
   return stream.str();
 }
 
-template <typename T> T hex_to_int(absl::string_view str) {
+template <typename T> T hex_to_int(armonik::api::string_view str) {
   char *endPos;
   std::string null_terminated(str.data(), str.size());
   T result = std::strtol(null_terminated.data(), &endPos, 16);
@@ -46,8 +46,8 @@ template <typename T> T hex_to_int(absl::string_view str) {
   return result;
 }
 
-absl::string_view advance_sv(absl::string_view &sv, size_t offset) {
-  absl::string_view extracted = sv.substr(0, offset);
+armonik::api::string_view advance_sv(armonik::api::string_view &sv, size_t offset) {
+  armonik::api::string_view extracted = sv.substr(0, offset);
   sv = sv.substr(offset);
   return extracted;
 }
@@ -70,7 +70,7 @@ std::string TaskPayload::Serialize() const {
   return ss.str();
 }
 
-TaskPayload TaskPayload::Deserialize(absl::string_view serialized) {
+TaskPayload TaskPayload::Deserialize(armonik::api::string_view serialized) {
   constexpr size_t size_width = sizeof(field_size_t) * 2;
   field_size_t fieldSize;
   std::vector<std::string> data_dependencies;
@@ -103,7 +103,7 @@ std::string ConventionPayload::Serialize() const {
   return j.dump();
 }
 
-ConventionPayload ConventionPayload::Deserialize(absl::string_view serialized) {
+ConventionPayload ConventionPayload::Deserialize(armonik::api::string_view serialized) {
   try {
     auto j = nlohmann::json::parse(serialized.begin(), serialized.end());
     ConventionPayload payload;

--- a/ArmoniK.SDK.DynamicWorker/src/ServiceManager.cpp
+++ b/ArmoniK.SDK.DynamicWorker/src/ServiceManager.cpp
@@ -1,5 +1,6 @@
 #include "ServiceManager.h"
 #include "ContextIds.h"
+#include <armonik/common/utils/string_view.h>
 #include <armonik/sdk/common/ArmoniKSdkException.h>
 #include <armonik/worker/Worker/ProcessStatus.h>
 #include <stdexcept>
@@ -68,7 +69,8 @@ void ServiceManager::UploadResult(void *opaque_context, armonik_status_t status,
     context->output.set_error(std::string(data, data_size));
     return;
   }
-  context->taskHandler.send_result(context->taskHandler.getExpectedResults()[0], absl::string_view(data, data_size));
+  context->taskHandler.send_result(context->taskHandler.getExpectedResults()[0],
+                                   armonik::api::string_view(data, data_size));
   context->output.set_ok();
 }
 bool ServiceManager::matches(const ServiceId &other) { return other == serviceId; }

--- a/ArmoniK.SDK.DynamicWorker/ubi8.Dockerfile
+++ b/ArmoniK.SDK.DynamicWorker/ubi8.Dockerfile
@@ -89,6 +89,12 @@ WORKDIR /tmp
 RUN wget https://github.com/aneoconsulting/grpc-rpm/releases/download/1.62.2.0/grpc-1.62.2-1.el8.x86_64.rpm && \
     rpm -ivh grpc-1.62.2-1.el8.x86_64.rpm && rm grpc-1.62.2-1.el8.x86_64.rpm
 
+# ArmoniK.Api ships shared libraries (libArmoniK.Api.*.so), so the runtime rpm must be installed here too,
+# not just in the builder stage, or the worker fails to start with a missing shared library error.
+ARG API_VERSION
+RUN wget "https://github.com/aneoconsulting/ArmoniK.Api/releases/download/${API_VERSION}/libarmonik-${API_VERSION}-Linux.rpm" && \
+    rpm -ivh "libarmonik-${API_VERSION}-Linux.rpm" && rm "libarmonik-${API_VERSION}-Linux.rpm"
+
 RUN adduser -d /home/armonikuser -u 5000 -U --shell /bin/sh armonikuser
 USER armonikuser
 

--- a/ArmoniK.SDK.DynamicWorker/ubi8.Dockerfile
+++ b/ArmoniK.SDK.DynamicWorker/ubi8.Dockerfile
@@ -44,8 +44,9 @@ RUN wget "https://github.com/aneoconsulting/grpc-rpm/releases/download/${GRPC_BU
 
 # Default value read from tools/common.sh file
 ARG API_VERSION
-RUN wget "https://github.com/aneoconsulting/ArmoniK.Api/releases/download/${API_VERSION}/libarmonik-${API_VERSION}-Linux.rpm" && \
-    rpm -ivh "libarmonik-${API_VERSION}-Linux.rpm"
+RUN wget "https://github.com/aneoconsulting/ArmoniK.Api/releases/download/${API_VERSION}/libarmonik-${API_VERSION}-Linux.rpm" \
+         "https://github.com/aneoconsulting/ArmoniK.Api/releases/download/${API_VERSION}/libarmonik-devel-${API_VERSION}-Linux.rpm" && \
+    rpm -ivh "libarmonik-${API_VERSION}-Linux.rpm" "libarmonik-devel-${API_VERSION}-Linux.rpm"
 
 RUN rm -rf *.rpm
 

--- a/tools/common.sh
+++ b/tools/common.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 # shellcheck disable=SC2034
-export ARMONIK_API_VERSION_DEFAULT="3.29.0"
+export ARMONIK_API_VERSION_DEFAULT="jf/stringview"
 export ARMONIK_SDK_VERSION_DEFAULT="0.1.0-local"

--- a/tools/common.sh
+++ b/tools/common.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 # shellcheck disable=SC2034
-export ARMONIK_API_VERSION_DEFAULT="jf/stringview"
+export ARMONIK_API_VERSION_DEFAULT="3.29.2"
 export ARMONIK_SDK_VERSION_DEFAULT="0.1.0-local"

--- a/tools/packaging/ubi8.Dockerfile
+++ b/tools/packaging/ubi8.Dockerfile
@@ -44,8 +44,9 @@ RUN wget "https://github.com/aneoconsulting/grpc-rpm/releases/download/${GRPC_BU
 
 # Default value read from tools/common.sh file
 ARG API_VERSION
-RUN wget "https://github.com/aneoconsulting/ArmoniK.Api/releases/download/${API_VERSION}/libarmonik-${API_VERSION}-Linux.rpm" && \
-    rpm -ivh "libarmonik-${API_VERSION}-Linux.rpm"
+RUN wget "https://github.com/aneoconsulting/ArmoniK.Api/releases/download/${API_VERSION}/libarmonik-${API_VERSION}-Linux.rpm" \
+         "https://github.com/aneoconsulting/ArmoniK.Api/releases/download/${API_VERSION}/libarmonik-devel-${API_VERSION}-Linux.rpm" && \
+    rpm -ivh "libarmonik-${API_VERSION}-Linux.rpm" "libarmonik-devel-${API_VERSION}-Linux.rpm"
 
 RUN rm -rf *.rpm
 


### PR DESCRIPTION
 # Motivation

  The SDK previously depended on `absl::string_view` (Abseil), pulling in an extra third-party dependency
  just for a `string_view`-like type. ArmoniK.Api now ships its own self-contained `string_view`
  implementation, so this dependency can be dropped in favor of the internal API implementation.

  # Description

  - Replaced all usages of `absl::string_view` with the internal
  `armonik::api::common::utils::string_view` implementation across `ArmoniK.SDK.Common` and
  `ArmoniK.SDK.Client` (`Configuration.h`/`.cpp`, `TaskPayload.h`/`.cpp`, `ConventionPayload.h`,
  `SessionServiceImpl.cpp`).
  - Added missing includes in `ServiceManager.cpp` and `End2EndHandlers.cpp` required after removing the
  Abseil header.
  - Bumped `ARMONIK_API_VERSION_DEFAULT` in `tools/common.sh` to `3.29.2`, the first ArmoniK.Api release
  that includes the self-contained `string_view`.
  - Updated both `ubi8.Dockerfile` files (`ArmoniK.SDK.DynamicWorker` and `tools/packaging`) to also
  download and install the `libarmonik-devel` RPM alongside the runtime RPM in the builder stage, since
  the devel package now needs to be present for the headers to be available.
  - Fixed `ArmoniK.SDK.DynamicWorker/ubi8.Dockerfile` to also install the `libarmonik` runtime RPM in the
  final worker runner stage, not just the builder stage: ArmoniK.Api ships shared libraries
  (`libArmoniK.Api.*.so`), and without them present in the runner image the worker failed to start with
  a missing shared library error.

  # Testing

  - Verified the project builds locally against ArmoniK.Api `3.29.2` with the `absl::string_view`
  dependency removed.
  - No functional/behavioral changes to SDK logic; changes are limited to the type used to pass string
  views and packaging/build configuration.

  # Impact

  - Removes the Abseil dependency requirement from the SDK's public headers (`Configuration.h`,
  `TaskPayload.h`, `ConventionPayload.h`), simplifying the dependency graph for consumers.
  - Requires ArmoniK.Api `>= 3.29.2`.
  - UBI8-based container images (DynamicWorker and packaging) now also install `libarmonik-devel`,
  slightly increasing image build-time dependencies but no runtime image size (installed during build
  stage).
  - Fixes a runtime startup failure in the DynamicWorker UBI8 image caused by the missing
  `libarmonik` shared library in the runner stage.

  # Additional Information

  N/A

  # Checklist

  - [x] My code adheres to the coding and style guidelines of the project.
  - [x] I have performed a self-review of my code.
  - [ ] I have commented my code, particularly in hard-to-understand areas.
  - [ ] I have made corresponding changes to the documentation.
  - [ ] I have thoroughly tested my modifications and added tests when necessary.
  - [x] Tests pass locally and in the CI.
  - [ ] I have assessed the performance impact of my modifications.
