### PR TITLE
chore: drop unused fmt-devel/libfmt-dev from Dockerfiles and docs

### DIFF
--- a/.docs/content/guide/1.installation.md
+++ b/.docs/content/guide/1.installation.md
@@ -52,7 +52,7 @@ rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 
 yum --disableplugin=subscription-manager install -y \
     make cmake git gcc gcc-c++ wget \
-    libcurl-devel fmt-devel simdjson-devel re2-devel \
+    libcurl-devel simdjson-devel re2-devel \
     zlib-devel openssl-devel
 ```
 

--- a/ArmoniK.SDK.DynamicWorker/ubi8.Dockerfile
+++ b/ArmoniK.SDK.DynamicWorker/ubi8.Dockerfile
@@ -14,7 +14,6 @@ RUN yum --disableplugin=subscription-manager update -y && \
     wget \
     rpm-build \
     libcurl-devel \
-    fmt-devel \
     simdjson-devel \
     re2-devel \
     zlib-devel \

--- a/tools/Dockerfile.vs
+++ b/tools/Dockerfile.vs
@@ -6,7 +6,6 @@ RUN apt-get update && DEBIAN_FRONTEND="noninteractive" TZ="Europe/London" apt-ge
     g++ \
     make \
     build-essential \
-    libfmt-dev \
     cmake \
     ssh \
     gdb \

--- a/tools/packaging/ubi8.Dockerfile
+++ b/tools/packaging/ubi8.Dockerfile
@@ -14,7 +14,6 @@ RUN yum --disableplugin=subscription-manager update -y && \
     wget \
     rpm-build \
     libcurl-devel \
-    fmt-devel \
     simdjson-devel \
     re2-devel \
     zlib-devel \


### PR DESCRIPTION
The fmt library is not used anywhere in this project's source or CMake build graph (a 2023 experiment adding it was reverted in the CMake files but the corresponding Dockerfile/doc package installs were never cleaned up). Sibling Debian/Ubuntu build pipelines already build the same targets without it.