### PR TITLE
fix: make ChannelPool::ChannelGuard move-only

### DIFF
--- a/ArmoniK.SDK.Client/private/ChannelPool.h
+++ b/ArmoniK.SDK.Client/private/ChannelPool.h
@@ -7,6 +7,7 @@
 #include <grpcpp/channel.h>
 #include <mutex>
 #include <queue>
+#include <utility>
 
 namespace ArmoniK {
 namespace Sdk {
@@ -112,6 +113,38 @@ public:
      * @param properties
      */
     ChannelGuard(Internal::ChannelPool *pool);
+
+    /**
+     * @brief Copy constructor (deleted, the guard owns a single release of the channel)
+     */
+    ChannelGuard(const ChannelGuard &) = delete;
+
+    /**
+     * @brief Copy assignment operator (deleted, the guard owns a single release of the channel)
+     */
+    ChannelGuard &operator=(const ChannelGuard &) = delete;
+
+    /**
+     * @brief Move constructor
+     */
+    ChannelGuard(ChannelGuard &&other) noexcept : channel(std::move(other.channel)), pool_(other.pool_) {
+      other.pool_ = nullptr;
+    }
+
+    /**
+     * @brief Move assignment operator
+     */
+    ChannelGuard &operator=(ChannelGuard &&other) noexcept {
+      if (this != &other) {
+        if (pool_ != nullptr) {
+          pool_->ReleaseChannel(channel);
+        }
+        channel = std::move(other.channel);
+        pool_ = other.pool_;
+        other.pool_ = nullptr;
+      }
+      return *this;
+    }
 
     /**
      * @brief Destroy the Channel Guard object

--- a/ArmoniK.SDK.Client/src/ChannelPool.cpp
+++ b/ArmoniK.SDK.Client/src/ChannelPool.cpp
@@ -86,7 +86,11 @@ ChannelPool::ChannelGuard::ChannelGuard(Internal::ChannelPool *pool) : pool_(poo
   }
 }
 
-ChannelPool::ChannelGuard::~ChannelGuard() { pool_->ReleaseChannel(channel); }
+ChannelPool::ChannelGuard::~ChannelGuard() {
+  if (pool_ != nullptr) {
+    pool_->ReleaseChannel(channel);
+  }
+}
 
 ChannelPool::ChannelGuard ChannelPool::GetChannel() { return ChannelGuard(this); }
 


### PR DESCRIPTION
# Motivation

  `ChannelPool::ChannelGuard` relied on RVO/NRVO to avoid double-releasing a channel back into the pool:
  it had a user-declared destructor but no move constructor/assignment, so the implicit copy constructor
  remained available and could double-release the channel if a copy were ever made instead of elided by
  the compiler.

  # Description

  Made `ChannelGuard` move-only:
  - Deleted the copy constructor and copy assignment operator.
  - Added an explicit move constructor and move assignment operator that transfer ownership of the
  channel and clear the source's `pool_`.
  - Guarded the destructor (and move assignment) against a moved-from guard by checking `pool_ !=
  nullptr` before calling `ReleaseChannel`.

  # Testing

  No automated tests were added; the change was verified by inspection given the small, self-contained
  scope. Build was checked to ensure existing usages of `ChannelGuard` (returned by value from
  `ChannelPool::GetChannel()`) still compile with move-only semantics.

  # Impact

  Prevents a potential double-release of a pooled channel if a `ChannelGuard` is ever copied instead of
  moved/elided, which could otherwise lead to undefined behaviour (use-after-release) in the channel
  pool. No behavioural change for existing correct usage; no new dependencies; no documentation changes
  required.

  # Additional Information

  None.

  # Checklist

  - [x] My code adheres to the coding and style guidelines of the project.
  - [x] I have performed a self-review of my code.
  - [x] I have commented my code, particularly in hard-to-understand areas.
  - [ ] I have made corresponding changes to the documentation.
  - [ ] I have thoroughly tested my modifications and added tests when necessary.
  - [ ] Tests pass locally and in the CI.
  - [x] I have assessed the performance impact of my modifications.
