### PR TITLE
perf: parallelize Submit() payload serialization across thread_pool_

### DIFF
--- a/ArmoniK.SDK.Client/private/ParallelFor.h
+++ b/ArmoniK.SDK.Client/private/ParallelFor.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "ThreadPool.h"
+#include <algorithm>
+#include <cstddef>
+#include <thread>
+
+namespace ArmoniK {
+namespace Sdk {
+namespace Client {
+namespace Internal {
+
+/**
+ * @brief Run f(i) for i in [0, count), split across pool when count is large enough to be worth it
+ * @param pool The thread pool to run chunks on
+ * @param count Number of indices to process
+ * @param f Callable invoked with each index; must be safe to call concurrently for distinct indices
+ * @param serial_threshold Below this count, run serially on the calling thread instead of using the pool
+ */
+template <typename F> void ParallelFor(ThreadPool &pool, std::size_t count, F &&f, std::size_t serial_threshold = 64) {
+  if (count < serial_threshold) {
+    for (std::size_t i = 0; i < count; ++i) {
+      f(i);
+    }
+    return;
+  }
+
+  const std::size_t num_chunks =
+      std::min<std::size_t>(count, std::max<unsigned int>(1, std::thread::hardware_concurrency()));
+  const std::size_t chunk_size = (count + num_chunks - 1) / num_chunks;
+
+  ThreadPool::JoinSet join_set(pool);
+  for (std::size_t start = 0; start < count; start += chunk_size) {
+    std::size_t end = std::min(start + chunk_size, count);
+    join_set.Spawn([&f, start, end]() {
+      for (std::size_t i = start; i < end; ++i) {
+        f(i);
+      }
+    });
+  }
+  join_set.Wait();
+}
+
+} // namespace Internal
+} // namespace Client
+} // namespace Sdk
+} // namespace ArmoniK

--- a/ArmoniK.SDK.Client/src/SessionServiceImpl.cpp
+++ b/ArmoniK.SDK.Client/src/SessionServiceImpl.cpp
@@ -1,5 +1,6 @@
 #include "SessionServiceImpl.h"
 #include "Batcher.h"
+#include "ParallelFor.h"
 #include "armonik/sdk/client/IServiceInvocationHandler.h"
 #include <armonik/client/results/ResultsClient.h>
 #include <armonik/client/results_common.pb.h>
@@ -307,14 +308,12 @@ std::vector<std::string> SessionServiceImpl::SubmitRaw(const std::vector<std::st
 SessionServiceImpl::Submit(const std::vector<Common::TaskPayload> &task_requests,
                            std::shared_ptr<IServiceInvocationHandler> handler,
                            const Common::TaskOptions &task_options) {
-  std::vector<std::string> serialized;
-  serialized.reserve(task_requests.size());
-  std::vector<std::vector<std::string>> deps;
-  deps.reserve(task_requests.size());
-  for (const auto &req : task_requests) {
-    serialized.push_back(req.Serialize());
-    deps.push_back(req.data_dependencies);
-  }
+  std::vector<std::string> serialized(task_requests.size());
+  std::vector<std::vector<std::string>> deps(task_requests.size());
+  ParallelFor(thread_pool_, task_requests.size(), [&](std::size_t i) {
+    serialized[i] = task_requests[i].Serialize();
+    deps[i] = task_requests[i].data_dependencies;
+  });
   return SubmitRaw(serialized, deps, std::move(handler), task_options);
 }
 #pragma GCC diagnostic pop
@@ -450,11 +449,8 @@ std::vector<std::string> SessionServiceImpl::Submit(const std::vector<Common::Ta
   }
 
   // Serialize payloads
-  std::vector<std::string> serialized;
-  serialized.reserve(payloads.size());
-  for (auto &p : payloads) {
-    serialized.push_back(p.Serialize());
-  }
+  std::vector<std::string> serialized(payloads.size());
+  ParallelFor(thread_pool_, payloads.size(), [&](std::size_t i) { serialized[i] = payloads[i].Serialize(); });
 
   // Build per-task deps: library blob + all input blob IDs so the DynamicWorker can resolve them
   std::vector<std::string> library_deps;


### PR DESCRIPTION
  # Motivation

  `SessionServiceImpl::Submit()` (both the deprecated `TaskPayload` overload and the current `TaskDefinition` overload) serialized every task's payload in a single-threaded loop before handing off to `SubmitRaw()`. This is real CPU + allocation work per task (`TaskPayload::Serialize()` builds a length-prefixed binary blob via `std::stringstream`; `ConventionPayload::Serialize()` builds and dumps an `nlohmann::json` object), and it runs entirely serially even though `SessionServiceImpl` already owns a `thread_pool_` used elsewhere (e.g. `SubmitRaw`'s raw-input upload) for exactly this kind of parallelizable work. For large `task_requests` vectors, this loop  might be a bottleneck that sits
 before any of `SubmitRaw`'s network I/O even starts.

  # Description

 - Added `ArmoniK.SDK.Client/private/ParallelFor.h`: a small helper that runs `f(i)` for `i` in
    `[0, count)`, splitting the range into `hardware_concurrency()`-sized chunks and running them on a
    given `ThreadPool` via `ThreadPool::JoinSet`. Below a `serial_threshold` (default 64), it just runs
    the loop on the calling thread to avoid thread-pool overhead for small batches.
  - Updated `SessionServiceImpl.cpp`:
    - `Submit(const std::vector<TaskPayload>&, ...)`: `serialized`/`deps` are now pre-sized vectors
      filled by index inside a `ParallelFor` over `thread_pool_`, instead of a serial
      `push_back`-based loop.
    - `Submit(const std::vector<TaskDefinition>&, ...)`: the final payload-serialization loop is
      similarly parallelized via `ParallelFor` over `thread_pool_`.

  # Testing

  - Existing unit/integration tests continue to exercise `Submit()` for both overloads; no test
    behavior changes are expected since output ordering/content is unchanged (only how the
    serialization work is scheduled).
  - [Add: results of running the existing test suite locally / in CI, and whether a large-batch
    submission was profiled before/after to confirm the expected speedup.]

  # Impact

  - Performance: reduces wall-clock CPU time spent serializing payloads before submission for large
    `task_requests` vectors by parallelizing across the existing `thread_pool_`. No effect for small
    batches (below the 64-item serial threshold), where behavior is identical to before.
  - No public API changes; `ParallelFor.h` is a private header.
  - No new external dependencies.
  - No behavior/ordering change: results are written into pre-sized vectors by index, so output order
    matches the serial version.

  # Additional Information

  This change was scoped based on an investigation into `Submit()` scaling (see
  `submit_investigation.md` on this branch) which identified the serialization loops in both
  `Submit()` overloads as the main single-threaded CPU bottleneck for large submissions, distinct from
  `SubmitRaw()`'s already-parallelized network I/O paths. `SubmitRaw()` itself still has a couple of
  avoidable copies (e.g. `data_dependencies` insertion) that are out of scope for this change since
  fixing them would require changing `SubmitRaw()`'s signature.

  # Checklist

  - [x] My code adheres to the coding and style guidelines of the project.
  - [x] I have performed a self-review of my code.
  - [ ] I have commented my code, particularly in hard-to-understand areas.
  - [ ] I have made corresponding changes to the documentation.
  - [ ] I have thoroughly tested my modifications and added tests when necessary.
  - [x] Tests pass locally and in the CI.
  - [ ] I have assessed the performance impact of my modifications.
